### PR TITLE
Ignoring domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,18 @@ For example:
 ],
 ```
 
+#### ☑️ Ignore Domains
+
+If for any reason you wish to disable StageFront on specific doamins, you can add these to the `ignore_udomains` array in the [configuration file](#-publish-configuration-file). You can't set this in the `.env` file.
+
+For example:
+
+```php
+'ignore_domains' => [
+    'admin.domain.com',
+],
+```
+
 #### ☑️ Link Live Site
 
 If you set the URL to your live site, a link will be shown underneath the login form.

--- a/config/stagefront.php
+++ b/config/stagefront.php
@@ -157,4 +157,14 @@ return [
      */
     'ignore_urls' => [],
 
+    
+    /**
+     * The following domains will be ignored by StageFront.
+     * Access to these domains will never be blocked.
+     * Default: []
+     * Example: 'admin.domain.com'
+     */
+    'ignore_domains' => [
+    ],
+
 ];

--- a/src/Shield.php
+++ b/src/Shield.php
@@ -55,6 +55,7 @@ class Shield
      */
     protected function currentUrlIsIgnored()
     {
+        $ignoredDomains = Config::get('stagefront.ignore_domains', []);
         $ignoredUrls = Config::get('stagefront.ignore_urls', []);
         $ignoredUrls[] = Config::get('stagefront.url');
 
@@ -62,6 +63,14 @@ class Shield
             $url = trim($url, '/');
 
             if (Request::is($url)) {
+                return true;
+            }
+        }
+
+        foreach ($ignoredDomains as $url) {
+            $url = trim($url, '/');
+
+            if (str_contains(Request::url(), $url)) {
                 return true;
             }
         }

--- a/tests/StageFrontTest.php
+++ b/tests/StageFrontTest.php
@@ -364,14 +364,14 @@ class StageFrontTest extends TestCase
         Config::set('app.url', 'http://domain.example.com');
         
         $this->url = Config::get('stagefront.url');
-        $this->registerRouteWithDomain('/public', 'Public');
+
+        $this->registerRouteWithDomain('/admin', 'Admin');
 
         Config::set('stagefront.ignore_domains', ['domain.example.com']);
 
         $this->enableStageFront();
 
-        $this->get('/public')->assertRedirect($this->url);
-        $this->get('http://domain.example.com/public')->assertStatus(200)->assertSee('Public');
+        $this->get('/admin')->assertStatus(200)->assertSee('Admin');
     }
 
     /** @test */

--- a/tests/StageFrontTest.php
+++ b/tests/StageFrontTest.php
@@ -514,7 +514,7 @@ class StageFrontTest extends TestCase
      */
     protected function registerRouteWithDomain($url, $text)
     {
-        Route::domain('domain.example.com')->group(function () {
+        Route::domain('domain.example.com')->group(function () use ($url) {
             Route::get($url, function () use ($text) {
                 return $text;
             })->middleware(Config::get('stagefront.middleware'));

--- a/tests/StageFrontTest.php
+++ b/tests/StageFrontTest.php
@@ -359,6 +359,25 @@ class StageFrontTest extends TestCase
     }
 
     /** @test */
+    public function domains_can_be_ignored_so_access_is_not_denied_by_stagefront()
+    {
+        Config::set('app.url', ['http://domain.example.com']);
+        
+        $this->url = Config::get('stagefront.url');
+        $this->registerRouteWithDomain('/page', 'Some Page');
+
+        $this->registerRouteWithDomain('/public', 'Public');
+        $this->registerRouteWithDomain('/public/route', 'Route');
+
+        Config::set('stagefront.ignore_domains', ['domain.example.com']);
+
+        $this->enableStageFront();
+
+        $this->get('/public')->assertRedirect($this->url);
+        $this->get('/public/route')->assertStatus(200)->assertSee('Route');
+    }
+
+    /** @test */
     public function ignored_urls_can_be_accessed_by_non_whitelisted_ips()
     {
         $this->url = Config::get('stagefront.url');
@@ -485,5 +504,20 @@ class StageFrontTest extends TestCase
         Route::get($url, function () use ($text) {
             return $text;
         })->middleware(Config::get('stagefront.middleware'));
+    }
+
+    /**
+     * Register a test route.
+     *
+     * @param string $url
+     * @param string $text
+     */
+    protected function registerRouteWithDomain($url, $text)
+    {
+        Route::domain('domain.example.com')->group(function () {
+            Route::get($url, function () use ($text) {
+                return $text;
+            })->middleware(Config::get('stagefront.middleware'));
+        });
     }
 }

--- a/tests/StageFrontTest.php
+++ b/tests/StageFrontTest.php
@@ -361,20 +361,17 @@ class StageFrontTest extends TestCase
     /** @test */
     public function domains_can_be_ignored_so_access_is_not_denied_by_stagefront()
     {
-        Config::set('app.url', ['http://domain.example.com']);
+        Config::set('app.url', 'http://domain.example.com');
         
         $this->url = Config::get('stagefront.url');
-        $this->registerRouteWithDomain('/page', 'Some Page');
-
         $this->registerRouteWithDomain('/public', 'Public');
-        $this->registerRouteWithDomain('/public/route', 'Route');
 
         Config::set('stagefront.ignore_domains', ['domain.example.com']);
 
         $this->enableStageFront();
 
         $this->get('/public')->assertRedirect($this->url);
-        $this->get('/public/route')->assertStatus(200)->assertSee('Route');
+        $this->get('http://domain.example.com/public')->assertStatus(200)->assertSee('Public');
     }
 
     /** @test */

--- a/tests/StageFrontTest.php
+++ b/tests/StageFrontTest.php
@@ -514,7 +514,7 @@ class StageFrontTest extends TestCase
      */
     protected function registerRouteWithDomain($url, $text)
     {
-        Route::domain('domain.example.com')->group(function () use ($url) {
+        Route::domain('domain.example.com')->group(function () use ($url, $text) {
             Route::get($url, function () use ($text) {
                 return $text;
             })->middleware(Config::get('stagefront.middleware'));

--- a/tests/StageFrontTest.php
+++ b/tests/StageFrontTest.php
@@ -361,8 +361,6 @@ class StageFrontTest extends TestCase
     /** @test */
     public function domains_can_be_ignored_so_access_is_not_denied_by_stagefront()
     {
-        Config::set('app.url', 'http://domain.example.com');
-        
         $this->url = Config::get('stagefront.url');
 
         $this->registerRouteWithDomain('/admin', 'Admin');
@@ -371,7 +369,7 @@ class StageFrontTest extends TestCase
 
         $this->enableStageFront();
 
-        $this->get('/admin')->assertStatus(200)->assertSee('Admin');
+        $this->call('GET', 'http://domain.example.com/admin')->assertStatus(200)->assertSee('Admin');
     }
 
     /** @test */


### PR DESCRIPTION
This PR add a configuration option to ignore [domains](https://laravel.com/docs/11.x/routing#route-group-subdomain-routing) in the same way as it is already possible for the urls.