### PR TITLE
Add PHP 8.5 test coverage

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,0 @@
-ko_fi: ivanvermeyen
-custom: https://paypal.me/ivanvermeyen

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,3 +1,3 @@
 # Security Policy
 
-If you discover any security related issues, please email ivan@codezero.be instead of using the issue tracker.
+If you discover any security related issues, please email james@jamesking.dev instead of using the issue tracker.

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         php: [ 8.0, 8.1, 8.2, 8.3 ]
-        laravel: [ 8.*, 9.*, 10.*, 11.* ]
+        laravel: [ 8.*, 9.*, 10.*, 11.*, 12.* ]
         dependency-version: [ prefer-stable ]
         include:
           - laravel: 5.7.*
@@ -52,12 +52,22 @@ jobs:
           - laravel: 11.*
             php: 8.3
             testbench: 9.*
+          - laravel: 12.*
+            php: 8.2
+            testbench: 10.*
+          - laravel: 12.*
+            php: 8.3
+            testbench: 10.*
         exclude:
           - laravel: 10.*
             php: 8.0
           - laravel: 11.*
             php: 8.0
           - laravel: 11.*
+            php: 8.1
+          - laravel: 12.*
+            php: 8.0
+          - laravel: 12.*
             php: 8.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,47 +8,10 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [ 8.0, 8.1, 8.2, 8.3 ]
-        laravel: [ 8.*, 9.*, 10.*, 11.*, 12.* ]
+        php: [ 8.2, 8.3, 8.4 ]
+        laravel: [ 11.*, 12.* ]
         dependency-version: [ prefer-stable ]
         include:
-          - laravel: 5.7.*
-            php: 7.2
-            testbench: 3.7.*
-          - laravel: 5.8.*
-            php: 7.2
-            testbench: 3.8.*
-          - laravel: 6.*
-            php: 7.2
-            testbench: 4.*
-          - laravel: 6.*
-            php: 8.0
-            testbench: 4.*
-          - laravel: 7.*
-            php: 7.2
-            testbench: 5.*
-          - laravel: 7.*
-            php: 8.0
-            testbench: 5.*
-          - laravel: 8.*
-            php: 7.3
-            testbench: 6.*
-          - laravel: 8.*
-            testbench: 6.*
-          - laravel: 9.*
-            testbench: 7.*
-          - laravel: 10.*
-            php: 8.1
-            testbench: 8.*
-          - laravel: 10.*
-            php: 8.2
-            testbench: 8.*
-          - laravel: 10.*
-            php: 8.3
-            testbench: 8.*
-          - laravel: 10.*
-            php: 8.4
-            testbench: 8.*
           - laravel: 11.*
             php: 8.2
             testbench: 9.*
@@ -67,17 +30,6 @@ jobs:
           - laravel: 12.*
             php: 8.4
             testbench: 10.*
-        exclude:
-          - laravel: 10.*
-            php: 8.0
-          - laravel: 11.*
-            php: 8.0
-          - laravel: 11.*
-            php: 8.1
-          - laravel: 12.*
-            php: 8.0
-          - laravel: 12.*
-            php: 8.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -46,17 +46,26 @@ jobs:
           - laravel: 10.*
             php: 8.3
             testbench: 8.*
+          - laravel: 10.*
+            php: 8.4
+            testbench: 8.*
           - laravel: 11.*
             php: 8.2
             testbench: 9.*
           - laravel: 11.*
             php: 8.3
+            testbench: 9.*
+          - laravel: 11.*
+            php: 8.4
             testbench: 9.*
           - laravel: 12.*
             php: 8.2
             testbench: 10.*
           - laravel: 12.*
             php: 8.3
+            testbench: 10.*
+          - laravel: 12.*
+            php: 8.4
             testbench: 10.*
         exclude:
           - laravel: 10.*

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,6 +1,7 @@
 name: Tests
 
-on: [ push, pull_request ]
+on:
+    pull_request:
 
 jobs:
   test:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -64,10 +64,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.composer/cache/files
           key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,28 +9,16 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [ 8.2, 8.3, 8.4 ]
-        laravel: [ 11.*, 12.* ]
-        dependency-version: [ prefer-stable ]
-        include:
-          - laravel: 11.*
-            php: 8.2
-            testbench: 9.*
-          - laravel: 11.*
-            php: 8.3
-            testbench: 9.*
-          - laravel: 11.*
-            php: 8.4
-            testbench: 9.*
-          - laravel: 12.*
-            php: 8.2
-            testbench: 10.*
-          - laravel: 12.*
-            php: 8.3
-            testbench: 10.*
-          - laravel: 12.*
-            php: 8.4
-            testbench: 10.*
+         php: [ 8.4 ]
+         laravel: [ 11.*, 12.* ]
+         dependency-version: [ prefer-stable ]
+         include:
+           - laravel: 11.*
+             php: 8.4
+             testbench: 9.*
+           - laravel: 12.*
+             php: 8.4
+             testbench: 10.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,15 +9,21 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-         php: [ 8.4 ]
+         php: [ 8.4, 8.5 ]
          laravel: [ 11.*, 12.* ]
          dependency-version: [ prefer-stable ]
          include:
            - laravel: 11.*
              php: 8.4
              testbench: 9.*
+           - laravel: 11.*
+             php: 8.5
+             testbench: 9.*
            - laravel: 12.*
              php: 8.4
+             testbench: 10.*
+           - laravel: 12.*
+             php: 8.5
              testbench: 10.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,7 @@
 # The MIT License (MIT)
 
 Copyright (c) 2017 Ivan Vermeyen (<ivan@codezero.be>)
+Copyright (c) 2025 James King (<james@jamesking.dev>)
 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ By installing StageFront with composer, adding the middleware and setting 3 vari
 
 ## ✅ Requirements
 
--   PHP ^7.1 | ^8.0
--   [Laravel](https://laravel.com/) >= 5.7
+-   PHP ^8.2
+-   [Laravel](https://laravel.com/) >= 11
 
 ## 📦 Installation
 
@@ -37,19 +37,7 @@ When StageFront is disabled, its routes will not be registered.
 
 #### ☑️ Install Middleware
 
-To activate the middleware, add it to the `web` middleware group in `app/Http/Kernel.php`, **right after the `StartSession` middleware**:
-
-```php
-protected $middlewareGroups = [
-    'web' => [
-        \Illuminate\Session\Middleware\StartSession::class, // <= after this
-        \CodeZero\StageFront\Middleware\RedirectIfStageFrontIsEnabled::class,
-        //...
-    ],
-];
-```
-
-In Laravel 6+ you need to add the middleware to the `$middlewarePriority` array in `app/Http/Kernel.php`, **right after the `StartSession` middleware**. 
+To activate the middleware, you need to add the middleware to the `$middlewarePriority` array in `app/Http/Kernel.php`, **right after the `StartSession` middleware**. 
 
 ```php
 protected $middlewarePriority = [
@@ -76,7 +64,7 @@ Enable StageFront and choose a login and password:
 | `STAGEFRONT_PASSWORD`  | `string` | `stagefront` |
 | `STAGEFRONT_ENCRYPTED` | `bool`   | `false`      |
 
-By default StageFront is disabled and uses a plain text password when it's enabled. If you set `STAGEFRONT_ENCRYPTED` to `true` the password should be a hashed value. You can generate this using Laravel's `\Hash::make('your password')` function.
+By default, StageFront is disabled and uses a plain text password when it's enabled. If you set `STAGEFRONT_ENCRYPTED` to `true` the password should be a hashed value. You can generate this using Laravel's `\Hash::make('your password')` function.
 
 ##### Artisan Commands for Quick Setup
 
@@ -113,13 +101,13 @@ The above login and password settings will then be ignored.
 | `STAGEFRONT_DATABASE_PASSWORD_FIELD` | `string` | `password` |
 
 If you want to grant access to just a few of those users, you can whitelist them by setting `STAGEFRONT_DATABASE_WHITELIST` to a comma separated string: `'john@doe.io,jane@doe.io'`.
-In the config file itself you can also use an array of e-mail addresses.
+In the config file itself, you can also use an array of e-mail addresses.
 
-By default the `users` table is used with the `email` and `password` field names. But you can change this if you are using some other table or fields.
+By default, the `users` table is used with the `email` and `password` field names. But you can change this if you are using some other table or fields.
 
 ## 🔖 IP Whitelist
 
-You can add a comma separated list of IP's to grant these users easier or exclusive access to your staging site.
+You can add a comma-separated list of IP's to grant these users easier or exclusive access to your staging site.
 For example: `'1.2.3.4,1.2.3.4'`. In the config file itself you can also use an array of IP's.
 
 | Option                                  | Type     | Default    |
@@ -141,7 +129,7 @@ Set `STAGEFRONT_IP_WHITELIST_REQUIRE_LOGIN` to `true` to set this up.
 
 #### ☑️ Change Route URL
 
-By default a `GET` and `POST` route will be registered with the `/stagefront` URL.
+By default, a `GET` and `POST` route will be registered with the `/stagefront` URL.
 
 You can change the URL by setting this option:
 
@@ -193,14 +181,14 @@ For example:
 'ignore_urls' => [
     // ignores /john, but noting under /john
     '/john',
-    // ignores everyting under /jane, but not /jane itself
+    // ignores everything under /jane, but not /jane itself
     '/jane/*',
 ],
 ```
 
 #### ☑️ Ignore Domains
 
-If for any reason you wish to disable StageFront on specific doamins, you can add these to the `ignore_udomains` array in the [configuration file](#-publish-configuration-file). You can't set this in the `.env` file.
+If for any reason you wish to disable StageFront on specific domains, you can add these to the `ignore_domains` array in the [configuration file](#-publish-configuration-file). You can't set this in the `.env` file.
 
 For example:
 
@@ -272,7 +260,7 @@ composer test
 
 ## 🔓 Security
 
-If you discover any security related issues, please [e-mail me](mailto:james@jamesking.dev) instead of using the issue tracker.
+If you discover any security-related issues, please [e-mail me](mailto:james@jamesking.dev) instead of using the issue tracker.
 
 ## 📑 Changelog
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Laravel StageFront
 
-[![GitHub release](https://img.shields.io/github/release/codezero-be/laravel-stagefront.svg?style=flat-square)](https://github.com/codezero-be/laravel-stagefront/releases)
+[![GitHub release](https://img.shields.io/github/release/jamesking56/laravel-stagefront.svg?style=flat-square)](https://github.com/jamesking56/laravel-stagefront/releases)
 [![Laravel](https://img.shields.io/badge/laravel-11-red?style=flat-square&logo=laravel&logoColor=white)](https://laravel.com)
-[![License](https://img.shields.io/packagist/l/codezero/laravel-stagefront.svg?style=flat-square)](LICENSE.md)
-[![Build Status](https://img.shields.io/github/actions/workflow/status/codezero-be/laravel-stagefront/run-tests.yml?style=flat-square&logo=github&logoColor=white&label=tests)](https://github.com/codezero-be/laravel-stagefront/actions)
-[![Code Quality](https://img.shields.io/codacy/grade/a5db8a1321664e67900c96eadc575ece/master?style=flat-square)](https://app.codacy.com/gh/codezero-be/laravel-stagefront)
-[![Total Downloads](https://img.shields.io/packagist/dt/codezero/laravel-stagefront.svg?style=flat-square)](https://packagist.org/packages/codezero/laravel-stagefront)
+[![License](https://img.shields.io/packagist/l/jamesking56/laravel-stagefront.svg?style=flat-square)](LICENSE.md)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/jamesking56/laravel-stagefront/run-tests.yml?style=flat-square&logo=github&logoColor=white&label=tests)](https://github.com/jamesking56/laravel-stagefront/actions)
+[![Code Quality](https://img.shields.io/codacy/grade/a5db8a1321664e67900c96eadc575ece/master?style=flat-square)](https://app.codacy.com/gh/jamesking56/laravel-stagefront)
+[![Total Downloads](https://img.shields.io/packagist/dt/jamesking56/laravel-stagefront.svg?style=flat-square)](https://packagist.org/packages/codezero/laravel-stagefront)
 
-[![ko-fi](https://www.ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/R6R3UQ8V)
+### RIP Ivan Vermeyen: thank you for your fantastic work
 
 #### Quickly add password protection to a staging site.
 
@@ -29,9 +29,9 @@ By installing StageFront with composer, adding the middleware and setting 3 vari
 #### ☑️ Require the package via Composer:
 
 ```bash
-composer require codezero/laravel-stagefront
+composer require jamesking56/laravel-stagefront
 ```
-Laravel will automatically register the [ServiceProvider](https://github.com/codezero-be/laravel-stagefront/blob/master/src/StageFrontServiceProvider.php) and routes.
+Laravel will automatically register the [ServiceProvider](https://github.com/jamesking56/laravel-stagefront/blob/master/src/StageFrontServiceProvider.php) and routes.
 
 When StageFront is disabled, its routes will not be registered.
 
@@ -65,7 +65,7 @@ Now you just need to set some `.env` variables and you are up and running!
 
 Set some options in your `.env` file or publish the [configuration file](#-publish-configuration-file).
 
-See an [example .env file](https://github.com/codezero-be/laravel-stagefront/blob/master/.env.example).
+See an [example .env file](https://github.com/jamesking56/laravel-stagefront/blob/master/.env.example).
 
 Enable StageFront and choose a login and password:
 
@@ -266,17 +266,18 @@ composer test
 
 ## ☕️ Credits
 
-- [Ivan Vermeyen](https://byterider.io/)
+- [Ivan Vermeyen (RIP)](https://byterider.io/)
+- [James King](https://jamesking.dev/)
 - [All contributors](../../contributors)
 
 ## 🔓 Security
 
-If you discover any security related issues, please [e-mail me](mailto:ivan@codezero.be) instead of using the issue tracker.
+If you discover any security related issues, please [e-mail me](mailto:james@jamesking.dev) instead of using the issue tracker.
 
 ## 📑 Changelog
 
 A complete list of all notable changes to this package can be found on the
-[releases page](https://github.com/codezero-be/laravel-stagefront/releases).
+[releases page](https://github.com/jamesking56/laravel-stagefront/releases).
 
 ## 📜 License
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ By installing StageFront with composer, adding the middleware and setting 3 vari
 
 ## ✅ Requirements
 
--   PHP ^8.2
+-   PHP ^8.4
 -   [Laravel](https://laravel.com/) >= 11
 
 ## 📦 Installation

--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,13 @@
         }
     ],
     "require": {
-        "php": "^7.1|^8.0",
+        "php": "^8.2",
         "codezero/dotenv-updater": "^1.1|^2.0",
-        "illuminate/support": "^5.7|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0"
+        "illuminate/support": "^11.0|^12.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^3.7|^4.0|^5.0|^6.0|^7.0|^8.0|^9.0|^10.0",
-        "phpunit/phpunit": "^7.0|^8.0|^9.0|^10.0|^11.5.3"
+        "orchestra/testbench": "^9.0|^10.0",
+        "phpunit/phpunit": "^10.0|^11.5.3"
     },
     "scripts": {
         "test": "phpunit"

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "codezero/laravel-stagefront",
+    "name": "jamesking56/laravel-stagefront",
     "description": "Quickly add some password protection to a staging site.",
     "keywords": [
         "laravel",
@@ -12,6 +12,10 @@
         {
             "name": "Ivan Vermeyen",
             "email": "ivan@codezero.be"
+        },
+        {
+            "name": "James King",
+            "email": "james@jamesking.dev"
         }
     ],
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,11 @@
     "require": {
         "php": "^7.1|^8.0",
         "codezero/dotenv-updater": "^1.1|^2.0",
-        "illuminate/support": "^5.7|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0"
+        "illuminate/support": "^5.7|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^3.7|^4.0|^5.0|^6.0|^7.0|^8.0|^9.0",
-        "phpunit/phpunit": "^7.0|^8.0|^9.0|^10.0"
+        "orchestra/testbench": "^3.7|^4.0|^5.0|^6.0|^7.0|^8.0|^9.0|^10.0",
+        "phpunit/phpunit": "^7.0|^8.0|^9.0|^10.0|^11.5.3"
     },
     "scripts": {
         "test": "phpunit"

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.4",
         "codezero/dotenv-updater": "^1.1|^2.0",
         "illuminate/support": "^11.0|^12.0"
     },


### PR DESCRIPTION
## Summary
- Add PHP 8.5 to the test matrix in GitHub Actions
- Test PHP 8.5 with both Laravel 11.x and 12.x
- Ensure compatibility with the latest PHP version